### PR TITLE
Add settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,7 +25,7 @@ indent_style = space
 atomic = true
 force_sort_within_sections = true
 include_trailing_comma = true
-known_third_party = flask,pytest
+known_third_party = decouple,flask,pytest
 multi_line_output = 3
 
 [*.rst]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+settings.ini
+
 # Created by https://www.gitignore.io/api/python
 # Edit at https://www.gitignore.io/?templates=python
 

--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,18 @@ Awards
 
 An application to manage PyGotham financial aid and scholarship applications and
 awards.
+
+=============
+Configuration
+=============
+
+Awards can be configured through either environment variables or a
+`settings.ini` file. An `example_settings.ini` file has been provided. You can
+kickstart your configuration with::
+
+    $ cp example_settings.ini settings.ini
+
+.. note::
+
+    Configuration for tests should be specified in the `testenv.setenv` section
+    of `tox.ini`.

--- a/awards/main.py
+++ b/awards/main.py
@@ -5,7 +5,7 @@ from flask import Flask, render_template
 
 def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
     app = Flask("awards")
-    app.config.from_mapping(SECRET_KEY="dev")
+    app.config.from_object("awards.settings")
 
     if test_config:
         app.config.from_mapping(test_config)

--- a/awards/settings.py
+++ b/awards/settings.py
@@ -1,0 +1,3 @@
+from decouple import config  # type: ignore[import]
+
+SECRET_KEY = config("SECRET_KEY")

--- a/example_settings.ini
+++ b/example_settings.ini
@@ -1,0 +1,2 @@
+[settings]
+SECRET_KEY=dev

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
 flask
+python-decouple

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ flask==1.1.1
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 markupsafe==1.1.1         # via jinja2
+python-decouple==3.3
 werkzeug==1.0.0           # via flask

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,7 @@ skipsdist = true
 deps =
     pytest
     -r{toxinidir}/requirements.txt
+setenv =
+    SECRET_KEY = test
 commands =
     pytest {posargs:tests}


### PR DESCRIPTION
This introduces [decouple](https://pypi.org/p/python-decouple) for
reading the configuration. A new `awards.settings` module will use it to
get the necessary configuration either from a `settings.ini` file
(preferred) or from the environment. The application instance will use
this module to get its configuration. This is better than the current
approach of passing the configuration to `create_app`. It also means the
application won't start without an explicit `SECRET_KEY` rather than
running with the hardcoded value of `"dev"`.

While `settings.ini` itself will be ignored, an `example_settings.ini`
is being provided. `README.rst` contains instructions for using it.