### PR TITLE
Add a base model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,7 +25,7 @@ indent_style = space
 atomic = true
 force_sort_within_sections = true
 include_trailing_comma = true
-known_third_party = decouple,flask,pytest
+known_third_party = decouple,flask,pytest,sqlalchemy
 multi_line_output = 3
 
 [*.rst]

--- a/.flake8
+++ b/.flake8
@@ -6,5 +6,6 @@ max-complexity = 18
 per-file-ignores =
     # TODO: This is necessary until there is a released version of pyflakes that
     # includes https://github.com/PyCQA/pyflakes/pull/455.
+    awards/db.py: F821
     tests/conftest.py: F821
 select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,5 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
+        additional_dependencies:
+          - sqlalchemy_stubs

--- a/awards/db.py
+++ b/awards/db.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+Session = sessionmaker()
+session = scoped_session(Session)
+
+Base = declarative_base()
+
+
+def init_app(app: Flask) -> None:
+    engine = create_engine(app.config["DATABASE_URI"])
+    Session.configure(bind=engine)  # type: ignore[no-untyped-call]
+
+    @app.teardown_request
+    def remove_session(exception: Optional[Exception] = None) -> None:
+        session.remove()  # type: ignore[no-untyped-call]

--- a/awards/main.py
+++ b/awards/main.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, Optional
 
 from flask import Flask, render_template
 
+from . import db
+
 
 def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
     app = Flask("awards")
@@ -9,6 +11,8 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
 
     if test_config:
         app.config.from_mapping(test_config)
+
+    db.init_app(app)
 
     @app.route("/")
     def home() -> str:

--- a/awards/settings.py
+++ b/awards/settings.py
@@ -1,3 +1,4 @@
 from decouple import config  # type: ignore[import]
 
+DATABASE_URI = config("DATABASE_URI")
 SECRET_KEY = config("SECRET_KEY")

--- a/example_settings.ini
+++ b/example_settings.ini
@@ -1,2 +1,3 @@
 [settings]
+DATABASE_URI=sqlite://
 SECRET_KEY=dev

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = sqlmypy

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 flask
 python-decouple
+sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 markupsafe==1.1.1         # via jinja2
 python-decouple==3.3
+sqlalchemy==1.3.13
 werkzeug==1.0.0           # via flask

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pytest
     -r{toxinidir}/requirements.txt
 setenv =
+    DATABASE_URI = sqlite://
     SECRET_KEY = test
 commands =
     pytest {posargs:tests}


### PR DESCRIPTION
This introduces [SQLAlchemy](https://www.sqlalchemy.org)'s
[ORM](https://docs.sqlalchemy.org/en/13/orm/) and adds a `Base` class
that can be used for all models.

The new `DATABASE_URI` setting must be provided (even though there are
no tables in the database yet).