### PR TITLE
Use Alembic for migrations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ ignore = E203, E266, E501, W503
 max-line-length = 80
 max-complexity = 18
 per-file-ignores =
+    alembic/env.py: E402
     # TODO: This is necessary until there is a released version of pyflakes that
     # includes https://github.com/PyCQA/pyflakes/pull/455.
     awards/db.py: F821

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,37 @@ jobs:
         run: |
           pre-commit run --all-files
 
+  migrations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('test-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test-requirements.txt
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Run tests
+        run: |
+          tox -e migrate
+
   test:
     runs-on: ubuntu-latest
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,87 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# The connection string is set inside alembic/env.py so that it can be
+# pulled from the application's settings.
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks=black
+# black.type=console_scripts
+# black.entrypoint=black
+# black.options=-l 79
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,88 @@
+# type: ignore
+"""isort:skip_file"""
+import os
+import os.path
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+import sys
+
+sys.path.insert(0, os.path.abspath(os.getcwd()))
+from awards import settings
+
+# Import Base from models so that the models are defined.
+from awards.db import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URI)
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+alembic
 flask
 python-decouple
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,16 @@
 #
 #    pip-compile
 #
+alembic==1.4.0
 click==7.0                # via flask
 flask==1.1.1
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
-markupsafe==1.1.1         # via jinja2
+mako==1.1.1               # via alembic
+markupsafe==1.1.1         # via jinja2, mako
+python-dateutil==2.8.1    # via alembic
 python-decouple==3.3
+python-editor==1.0.4      # via alembic
+six==1.14.0               # via python-dateutil
 sqlalchemy==1.3.13
 werkzeug==1.0.0           # via flask

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,14 @@ setenv =
     SECRET_KEY = test
 commands =
     pytest {posargs:tests}
+
+[testenv:migrate]
+deps =
+    -r{toxinidir}/requirements.txt
+setenv =
+    DATABASE_URI = sqlite://
+    SECRET_KEY = migrations
+commands =
+    alembic upgrade head
+    alembic downgrade base
+    alembic upgrade head


### PR DESCRIPTION
[Alembic](https://alembic.sqlalchemy.org) is a library for managing
migrations for [SQLAlchemy](https://www.sqlalchemy.org) tables. There
are no tables to migrate yet, but this will add the initial setup. A
couple of modifications are being made to the default template: the
application's `Base` class's metadata is being provided to Alembic and
the current working directory is being added to `sys.path` so that
Alembic can import from `awards`.

In addition to adding Alembic, a new tox environment is being added to
test that migrations are forwards and backwards compatible. This is
being added to GitHub Actions as a new job.