### PR TITLE
Check that migrations have been generated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,14 @@ repos:
         args: ["--strict"]
         additional_dependencies:
           - sqlalchemy_stubs
+  - repo: local
+    hooks:
+      - id: alembic-autogen-check
+        name: alembic-autogen-check
+        additional_dependencies:
+          - tox
+        entry: tox -e alembic-autogen-check
+        pass_filenames: false
+        language: python
+        types:
+          - python

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,16 @@ setenv =
 commands =
     pytest {posargs:tests}
 
+[testenv:alembic-autogen-check]
+deps =
+    alembic-autogen-check
+    -r{toxinidir}/requirements.txt
+setenv =
+    DATABASE_URI = sqlite://
+    SECRET_KEY = migrations
+commands =
+    alembic-autogen-check
+
 [testenv:migrate]
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This will add a [pre-commit](https://pre-commit.com) hook to run
[alembic-autogen-check](https://pypi.org/p/alembic-autogen-check) to
ensure that the Alembic migrations are up-to-date. It will run whenever
a Python file is being committed. In the future, we may want to consider
limiting the scope to files that contain model definitions.

Unfortunately there's no way to get pre-commit to install from a
`requirements.txt` file (see
https://github.com/pre-commit/pre-commit/issues/730#issuecomment-374463792),
so [tox](https://pypi.org/p/tox) is being used to run
`alembic-autogen-check`.