### PR TITLE
Only check migrations are up-to-date in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,10 @@ jobs:
           pip install -r test-requirements.txt
         if: steps.cache.outputs.cache-hit != 'true'
 
-      - name: Run tests
+      - name: Test migrations
         run: |
-          tox -e migrate
+          tox -e check-migrations
+          tox -e test-migrations
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,14 +58,3 @@ repos:
         args: ["--strict"]
         additional_dependencies:
           - sqlalchemy_stubs
-  - repo: local
-    hooks:
-      - id: alembic-autogen-check
-        name: alembic-autogen-check
-        additional_dependencies:
-          - tox
-        entry: tox -e alembic-autogen-check
-        pass_filenames: false
-        language: python
-        types:
-          - python

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 commands =
     pytest {posargs:tests}
 
-[testenv:alembic-autogen-check]
+[testenv:check-migrations]
 deps =
     alembic-autogen-check
     -r{toxinidir}/requirements.txt
@@ -20,9 +20,10 @@ setenv =
     DATABASE_URI = sqlite://
     SECRET_KEY = migrations
 commands =
+    alembic upgrade head
     alembic-autogen-check
 
-[testenv:migrate]
+[testenv:test-migrations]
 deps =
     -r{toxinidir}/requirements.txt
 setenv =


### PR DESCRIPTION
It turns out that checking if the
[Alembic](https://alembic.sqlalchemy.org] are up-to-date can be a
relatively expensive operation, at least compared to what you typically
want to see when using [pre-commit](https://pre-commit.com) hooks. Not
only do you need to install all of the dependencies, but you also need
to run all of your migrations first. On top of that, because our
dependencies can't reasonably be enumerated in our
[tox](https://pypi.org/p/tox) configuration, the environment needs to be
recreated on each run.

The trade off here is that no one will receive feedback about missing
migrations until CI. As the sole contributor to the project at this
time, though, that's a trade off I'm okay with. If future contributors
ever see a non-trivial number of CI failures because of this, we can
revisit this approach.

Since the two tox environments will be invoked in the same CI step, they
are being renamed so that the intention of each is clearer.

Closes #11