### PR TITLE
Use Postgres as the database

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,18 @@ jobs:
   migrations:
     runs-on: ubuntu-latest
 
+    services:
+      db:
+        image: postgres:12.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,12 +57,25 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Test migrations
+        env:
+          DATABASE_URI_MIGRATIONS: postgresql+psycopg2://postgres:postgres@localhost/postgres
         run: |
-          tox -e check-migrations
-          tox -e test-migrations
+          tox -e migrations
 
   test:
     runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: postgres:12.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - uses: actions/checkout@v2
@@ -77,5 +102,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run tests
+        env:
+          DATABASE_URI_TESTS: postgresql+psycopg2://postgres:postgres@localhost/postgres
         run: |
           tox

--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,40 @@ kickstart your configuration with::
 
     Configuration for tests should be specified in the `testenv.setenv` section
     of `tox.ini`.
+
+=======
+Testing
+=======
+
+While all tests will be as part of CI, they can also be run locally through
+tox_.
+
+----------
+Unit tests
+----------
+
+The unit tests will be run whenever tox is envoked without specifying an
+environment, but can be run directly with::
+
+    $ tox -e py38
+
+The test environment require access to a database. It's connection string must
+be specified through the `DATABASE_URI_TESTS` environment variable::
+
+    $ env DATABASE_URI_TESTS=postgresql+psycopg2://user:password@host:port/dbname tox -e py38
+
+-------------------
+Checking migrations
+-------------------
+
+You can check both that all necessary migration files have been created and
+that all migrations can be run (in both directions) successfully::
+
+    $ tox -e migrations
+
+The tox environment require access to a database. It's connection string must
+be specified through the `DATABASE_URI_MIGRATIONS` environment variable::
+
+    $ env DATABASE_URI_MIGRATIONS=postgresql+psycopg2://user:password@host:port/dbname tox -e migrations
+
+.. _tox: https://tox.readthedocs.io

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 alembic
 flask
+psycopg2-binary
 python-decouple
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 mako==1.1.1               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
+psycopg2-binary==2.8.4
 python-dateutil==2.8.1    # via alembic
 python-decouple==3.3
 python-editor==1.0.4      # via alembic

--- a/tox.ini
+++ b/tox.ini
@@ -7,29 +7,20 @@ deps =
     pytest
     -r{toxinidir}/requirements.txt
 setenv =
-    DATABASE_URI = sqlite://
+    DATABASE_URI = {env:DATABASE_URI_TESTS}
     SECRET_KEY = test
 commands =
     pytest {posargs:tests}
 
-[testenv:check-migrations]
+[testenv:migrations]
 deps =
     alembic-autogen-check
     -r{toxinidir}/requirements.txt
 setenv =
-    DATABASE_URI = sqlite://
+    DATABASE_URI = {env:DATABASE_URI_MIGRATIONS}
     SECRET_KEY = migrations
 commands =
     alembic upgrade head
     alembic-autogen-check
-
-[testenv:test-migrations]
-deps =
-    -r{toxinidir}/requirements.txt
-setenv =
-    DATABASE_URI = sqlite://
-    SECRET_KEY = migrations
-commands =
-    alembic upgrade head
     alembic downgrade base
     alembic upgrade head


### PR DESCRIPTION
While the plan had always been to use
[Postgres](https://www.postgresql.org) as the database, the goal was to
introduce it as late as possible to keep the developer experience as
simple as possible for as long as possible. Unfortunately the migration
tests in #13 are failing because the database doesn't persist across
commands in the [tox](https://tox.readthedocs.io) environments.

Rather than spending time making changes to the tox environments just to
try to stick to in-memory [SQLite](https://www.sqlite.org) for a little
longer, this will move the project over to Postgres right now. The
`check-migrations` environment is being merged with the
`test-migrations` environment to simplify managing them. They're now
known as `migrations`.

Each tox environment that requires a database will look for a specific
environment variable that it will then pass along to the application as
`DATABASE_URI`.