### PR TITLE
Use a better name for the unit tests environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,12 @@ Unit tests
 The unit tests will be run whenever tox is envoked without specifying an
 environment, but can be run directly with::
 
-    $ tox -e py38
+    $ tox -e unit
 
 The test environment require access to a database. It's connection string must
 be specified through the `DATABASE_URI_TESTS` environment variable::
 
-    $ env DATABASE_URI_TESTS=postgresql+psycopg2://user:password@host:port/dbname tox -e py38
+    $ env DATABASE_URI_TESTS=postgresql+psycopg2://user:password@host:port/dbname tox -e unit
 
 -------------------
 Checking migrations

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py38
+envlist = unit
 skipsdist = true
 
-[testenv]
+[testenv:unit]
 deps =
     pytest
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This project doesn't need to support multiple versions of Python.
There's no need to name a tox environment after one just because that's
a thing you can do. By renaming the environment from `py38` to `unit`,
not only do we better convey what the environment is testing, but it's
also one less thing that has to be changed when we upgrade to a newer
version of Python.