### PR TITLE
Run tests in parallel in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,4 +105,4 @@ jobs:
         env:
           DATABASE_URI_TESTS: postgresql+psycopg2://postgres:postgres@localhost/postgres
         run: |
-          tox
+          tox --parallel=auto


### PR DESCRIPTION
[tox](https://tox.readthedocs.io) supports [running tests in
parallel](https://tox.readthedocs.io/en/latest/example/basic.html#parallel-mode).
We should take advantage of that to speed up CI. By setting the value to
`auto`, to max out the number of parallel jobs at the CPU count.