### PR TITLE
Better explain warnings ignored by flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,8 +5,8 @@ max-line-length = 80
 max-complexity = 18
 per-file-ignores =
     migrations/env.py: E402
-    # TODO: This is necessary until there is a released version of pyflakes that
-    # includes https://github.com/PyCQA/pyflakes/pull/455.
+    # TODO: The F821s are necessary until there is a released version of
+    # pyflakes that includes https://github.com/PyCQA/pyflakes/pull/455.
     awards/db.py: F821
     tests/conftest.py: F821
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
The `TODO` comment in `.flake8` is specifically targeted at the
[F821](https://flake8.pycqa.org/en/3.7.9/user/error-codes.html) errors
caused by ignoring specific
[mypy error codes](https://mypy.readthedocs.io/en/stable/error_codes.html#error-codes).
This will make it clearer to which things "This" (and really it should
have been "These") refers.