### PR TITLE
Run CI for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
Currently CI is triggered anytime a branch is pushed to GitHub. Since
pull requests are associated with branches, GitHub is able to match the
jobs to the appropriate PR. This works fine for PRs created from within
the repository but won't help with ones created from forks. By adding
`pull_request` to the list of events that trigger CI, we can fix this.

This will then have the unfortunate side effect of running CI twice for
branches associated with PRs. This can be addressed by limiting `push`
events to the `master` branch.

The only downside here is that CI won't run for a branch until it's been
associated with a PR, but that is a minor problem -- and one that can be
easily addressed by creating a PR -- compared to not having any CI at
all for some PRs.

Thanks [@jefftriplett][jeff] for the idea.

[jeff]: https://twitter.com/webology/status/1254091755026288640