### PR TITLE
Sort first-party libraries properly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,7 +25,7 @@ indent_style = space
 atomic = true
 force_sort_within_sections = true
 include_trailing_comma = true
-known_third_party = awards,decouple,django,pytest,sesame,users
+known_third_party = decouple,django,pytest,sesame
 multi_line_output = 3
 
 [*.rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     rev: v1.9.4
     hooks:
       - id: seed-isort-config
+        args: ['--application-directories=src']
   - repo: https://github.com/timothycrosley/isort
     rev: 4.3.21
     hooks:

--- a/src/awards/urls.py
+++ b/src/awards/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
+
 from users.views import login, magic_login
 
 urlpatterns = [

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from users.views import profile
 
 urlpatterns = [

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from awards.types import HttpRequestWithUser
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
@@ -9,6 +8,8 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from sesame.utils import get_query_string, get_user
+
+from awards.types import HttpRequestWithUser
 
 
 def login(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
By default, [seed-isort-config][seed-isort-config] looks in the current
working directory for first-party libraries. All of the first-party
libraries for this project, however, live inside a `src` directory.

The `--application-directories` argument is being set in the
[pre-commit][pre-commit] config so that first-party libraries will be
sorted as such.

[seed-isort-config]: https://pypi.org/p/seed-isort-config
[pre-commit]: https://pre-commit.com