### PR TITLE
Add tests for logging in

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,7 @@
+from django.test import Client
+
+
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def client() -> Client:
+    # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+    return Client()

--- a/src/users/test_views.py
+++ b/src/users/test_views.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import Client
+import pytest
+
+TEST_EMAIL = "user@example.org"
+
+# pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+User = get_user_model()
+
+
+@pytest.mark.django_db
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def test_login_creates_new_user(client: Client) -> None:
+    assert not User.objects.filter(email=TEST_EMAIL)
+    client.post("/login", {"email": TEST_EMAIL})
+    assert User.objects.filter(email=TEST_EMAIL)[0]
+
+
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def test_login_requires_email(client: Client) -> None:
+    response = client.post("/login")
+    assert response.status_code not in (301, 302)
+    assert b"this field is required" in response.content.lower()

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -34,6 +34,7 @@ def login(request: HttpRequest) -> HttpResponse:
                 html_message=message,
             )
 
+            # TODO: This should probably be a redirect instead.
             return HttpResponse("email sent")
     else:
         form = LoginForm()


### PR DESCRIPTION
For the most part I trust `LoginForm` and [django-sesame][django-sesame]
to work, but it's good to make sure that our custom login behavior
works, namely that a new `User` will be created whenever a new email
address is submitted. This will also test that forms without an email
addressed don't validate.

[django-sesame]: https://django-sesame.readthedocs.io