### PR TITLE
Add lazy translation to placeholder in login form

### DIFF
--- a/src/users/forms.py
+++ b/src/users/forms.py
@@ -1,7 +1,8 @@
 from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 
 class LoginForm(forms.Form):
     email = forms.EmailField(
-        widget=forms.EmailInput(attrs={"placeholder": "Email address"})
+        widget=forms.EmailInput(attrs={"placeholder": _("Email address")})
     )


### PR DESCRIPTION
While there aren't any immediate plans to ship translations for the
site, it's a good idea to mark text as translatable whenever possible to
make it easier to ship them in the future.