### PR TITLE
Redact email addresses

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,5 +9,6 @@ per-file-ignores =
     # can be used.
     src/applications/models.py: B950
     src/users/migrations/0001_initial.py: B950
+    src/users/models.py: B950
     src/users/views.py: B950
 select = B,C,E,F,W,T4,B9

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -21,4 +21,8 @@ class User(AbstractBaseUser):
     REQUIRED_FIELDS = []
 
     def __str__(self) -> str:
-        return str(self.email)
+        # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+        username, domain = self.email.split("@", 1)
+
+        # Hide the characters in the username other than the first one.
+        return f"{username[0]}{'*' * (len(username) - 1)}@{domain}"


### PR DESCRIPTION
The default string representation of a `User` is their email address.
Even though access to the data will be restricted, it's a bad idea to
display someone's email address on a web page. It could also lead to
bias when reviewing their application as you may see their name in their
email address.

We may need to consider redacting the domains as well but for now this
is a good start.