### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: autoflake
         args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
         args: ['--application-directories=src']
@@ -42,7 +42,7 @@ repos:
       - id: black
         language_version: python3.8
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.0a2
     hooks:
       - id: flake8
         additional_dependencies:


### PR DESCRIPTION
These [pre-commit][pre-commit] hooks offer newer versions and are being
updated via:

    pre-commit autoupdate

[pre-commit]: https://pre-commit.com