### PR TITLE
Switch to Jazzband's pip-tools pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,8 @@ repos:
       - id: requirements-txt-fixer
         files: requirements\.in$
       - id: trailing-whitespace
-  # TODO: Switch to jazzband if https://github.com/jazzband/pip-tools/pull/976
-  # is ever merged and tagged.
-  - repo: https://github.com/atugushev/pip-tools
-    rev: 848aad835e88f438727b367f2c7c82277de29e46
+  - repo: https://github.com/jazzband/pip-tools
+    rev: 5.1.2
     hooks:
       - id: pip-compile
       - id: pip-compile

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,12 +8,12 @@ appdirs==1.4.3            # via virtualenv
 asgiref==3.2.7            # via django
 aspy.yaml==1.3.0          # via pre-commit
 cfgv==3.0.0               # via pre-commit
-django-debug-toolbar==2.2
+django-debug-toolbar==2.2  # via -r dev-requirements.in
 django==3.0.5             # via django-debug-toolbar
 filelock==3.0.12          # via virtualenv
 identify==1.4.11          # via pre-commit
 nodeenv==1.3.5            # via pre-commit
-pre-commit==2.0.1
+pre-commit==2.0.1         # via -r dev-requirements.in
 pytz==2019.3              # via django
 pyyaml==5.3               # via aspy.yaml, pre-commit
 six==1.14.0               # via virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@
 #    pip-compile
 #
 asgiref==3.2.7            # via django
-django-sesame==1.7
-django==3.0.5
-psycopg2-binary==2.8.4
-python-decouple==3.3
+django-sesame==1.7        # via -r requirements.in
+django==3.0.5             # via -r requirements.in
+psycopg2-binary==2.8.4    # via -r requirements.in
+python-decouple==3.3      # via -r requirements.in
 pytz==2019.3              # via django
 sqlparse==0.3.1           # via django
-ua-parser==0.10.0
+ua-parser==0.10.0         # via -r requirements.in

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,5 +13,5 @@ py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox==3.14.5
+tox==3.14.5               # via -r test-requirements.in
 virtualenv==20.0.4        # via tox


### PR DESCRIPTION
How that https://github.com/jazzband/pip-tools/pull/976 has been merged
and released, we can switch to version of the [pip-tools][pip-tools]
[pre-commit][pre-commit] hook provided by [Jazzband][jazzband].

[jazzband]: https://github.com/jazzband
[pip-tools]: https://pypi.org/p/pip-tools
[pre-commit]: https://pre-commit.com