### PR TITLE
Allow application type migration to be reversed

### DIFF
--- a/src/applications/migrations/0002_application_type.py
+++ b/src/applications/migrations/0002_application_type.py
@@ -26,5 +26,7 @@ class Migration(migrations.Migration):
                 max_length=11,
             ),
         ),
-        migrations.RunPython(set_application_type_to_default),
+        migrations.RunPython(
+            set_application_type_to_default, reverse_code=migrations.RunPython.noop
+        ),
     ]


### PR DESCRIPTION
The migration to add the type of application to `Application` includes a
data migration through the [`RunPython`][runpython] operation. By
default, these operations are irreversible. Since reversing the
migration would drop the column, there's no harm in making the reverse
of the data migration a noop.

[runpython]: https://docs.djangoproject.com/en/3.0/ref/migration-operations/#django.db.migrations.operations.RunPython