### PR TITLE
Use the real gettext_lazy

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,8 +7,10 @@ per-file-ignores =
     src/awards/settings/dev.py: F405
     # TODO: Remove these once https://github.com/facebook/pyre-check/pull/256
     # can be used.
+    src/applications/forms.py: B950
     src/applications/models.py: B950
     src/users/migrations/0001_initial.py: B950
+    src/users/forms.py: B950
     src/users/models.py: B950
     src/users/views.py: B950
 select = B,C,E,F,W,T4,B9

--- a/src/applications/forms.py
+++ b/src/applications/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from applications.models import Application
 
@@ -16,7 +16,9 @@ class FinancialAidApplicationForm(ApplicationForm):
         model = Application
         fields = ("background", "reason_to_attend")
         labels = {
+            # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
             "background": _("Tell us a little bit more about yourself"),
+            # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
             "reason_to_attend": _("Why are you interested in attending PyGotham?"),
         }
 
@@ -28,6 +30,8 @@ class ScholarshipApplicationForm(ApplicationForm):
         model = Application
         fields = ("background", "reason_to_attend")
         labels = {
+            # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
             "background": _("Tell us a little bit about yourself"),
+            # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
             "reason_to_attend": _("Why are you interested in attending PyGotham?"),
         }

--- a/src/users/forms.py
+++ b/src/users/forms.py
@@ -1,8 +1,9 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class LoginForm(forms.Form):
     email = forms.EmailField(
+        # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
         widget=forms.EmailInput(attrs={"placeholder": _("Email address")})
     )


### PR DESCRIPTION
Since [Django][django] 2.0, `ugettext_lazy` has been an alias for
`gettext_lazy`. By switching to the real implementation, the deprecation
warnings will go away, making the output from the unit tests much easier
to parse.

[django]: https://www.djangoproject.com