### PR TITLE
Assign errors to specific financial aid form fields

### DIFF
--- a/src/applications/forms.py
+++ b/src/applications/forms.py
@@ -51,23 +51,33 @@ class FinancialAidApplicationForm(ApplicationForm):
         travel_amount = cleaned_data.get("travel_amount") or 0
         if travel_amount < 0:
             raise forms.ValidationError(
-                # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
-                _("Your estimated travel costs cannot be negative.")
+                {
+                    # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
+                    "travel_amount": _(
+                        "Your estimated travel costs cannot be negative."
+                    )
+                }
             )
 
         travel_requested = cleaned_data.get("travel_requested")
         if travel_requested:
             if not travel_amount:
                 raise forms.ValidationError(
-                    # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
-                    _("Your estimated travel costs must be greater than $0.00.")
+                    {
+                        # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
+                        "travel_amount": _(
+                            "Your estimated travel costs must be greater than $0.00."
+                        )
+                    }
                 )
         elif travel_amount:
             raise forms.ValidationError(
-                # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
-                _(
-                    "You must request travel assistance before providing an estimated cost."
-                )
+                {
+                    # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/262.
+                    "travel_requested": _(
+                        "You must request travel assistance before providing an estimated cost."
+                    )
+                }
             )
 
         return cleaned_data

--- a/src/applications/test_forms.py
+++ b/src/applications/test_forms.py
@@ -17,16 +17,13 @@ def test_financial_aid_travel_amount_must_be_greater_than_zero() -> None:
         {"travel_requested": True, "travel_amount": -1, **other_fields}
     )
     assert not form.is_valid()
-    assert "Your estimated travel costs cannot be negative." in form.errors["__all__"]
+    assert "travel_amount" in form.errors
 
     form = FinancialAidApplicationForm(
         {"travel_requested": True, "travel_amount": 0, **other_fields}
     )
     assert not form.is_valid()
-    assert (
-        "Your estimated travel costs must be greater than $0.00."
-        in form.errors["__all__"]
-    )
+    assert "travel_amount" in form.errors
 
     form = FinancialAidApplicationForm(
         {"travel_requested": True, "travel_amount": 1, **other_fields}
@@ -41,7 +38,4 @@ def test_financial_aid_travel_must_be_requested_if_amount_specified() -> None:
         {"travel_requested": False, "travel_amount": 1, **other_fields}
     )
     assert not form.is_valid()
-    assert (
-        "You must request travel assistance before providing an estimated cost."
-        in form.errors["__all__"]
-    )
+    assert "travel_requested" in form.errors


### PR DESCRIPTION
When raising a [`ValidationError`][validationerror], it's common to
provide it with a single string containing the error message. It turns
out it can also take a list of strings. Just as with a single string,
the list will be handled as form-level errors.

`ValidationError` accepts a third kind of message: a dictionary. When
providing a dictionary, the keys represent the names of the fields with
which the errors should be associated.

`FinancialAidApplicationForm.clean` can utilize this behavior to better
associate the errors with their fields. This will also simplify the
tests.

I'm removing the checks for the specific error text as this tends to be
brittle. I did catch a missing "." at the end of a message when I wrote
one, but our checks are pretty straightforward, so hopefully the simpler
checks are good enough.

[validationerror]: https://github.com/django/django/blob/d6aff369ad33457ae2355b5b210faf1c4890ff35/django/core/exceptions.py#L101-L108