### PR TITLE
Add coverage reporting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[.coveragerc]
+indent_size = 4
+indent_style = space
+
 [.flake8]
 indent_size = 4
 indent_style = space

--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+omit =
+    */migrations/*
+    */site-packages/*
+
+[run]
+branch = true
+data_file = ../.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = unit
+envlist =
+    unit
+    coverage
 skipsdist = true
 
 [testenv]
@@ -15,6 +17,12 @@ setenv =
     unit: DJANGO_SETTINGS_MODULE = awards.settings.ci
 changedir =
     {toxinidir}/src
+
+[testenv:coverage]
+deps =
+    coverage
+commands =
+    coverage report
 
 [testenv:makemigrations]
 commands =
@@ -45,7 +53,8 @@ commands =
 
 [testenv:unit]
 deps =
+    coverage
     pytest-django
     -r{toxinidir}/requirements.txt
 commands =
-    pytest {posargs}
+    coverage run --m pytest {posargs}


### PR DESCRIPTION
While not essential, this adds [coverage][coverage] reporting to the
unit tests. Django executes a lot of the code when it starts up, so the
report isn't perfect, but it at least gives a sense of how much of the
code is actually being used.

[coverage]: https://pypi.org/p/coverage
