### PR TITLE
Set the login view

### DIFF
--- a/src/awards/settings/base.py
+++ b/src/awards/settings/base.py
@@ -92,6 +92,8 @@ AUTHENTICATION_BACKENDS = [
     "sesame.backends.ModelBackend",
 ]
 
+LOGIN_URL = "login"
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/


### PR DESCRIPTION
By default `/accounts/login` is used. By setting the
[`LOGIN_URL`][loginurl] to the name of the URL pattern, the
[`login_required`][loginrequired] decorator will redirect users to the
correct URL.

[loginrequired]: https://docs.djangoproject.com/en/3.0/topics/auth/default/#the-login-required-decorator
[loginurl]: https://docs.djangoproject.com/en/3.0/ref/settings/#login-url