### PR TITLE
Make it easier to use a debugger with runserver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,14 @@ environments.
     either a forward or backward migration can be specified as well.
 
 ``runserver``
-    Run the development server with watchman_ watching for changes.
+    Run the development server with watchman_ watching for changes. If the
+    ``PYTPYTHONBREAKPOINT`` environment variable is set, it will be passed
+    through to the environment. The following debuggers are supported:
+
+    * bpdb
+    * ipdb
+    * pdb
+    * pudb
 
 ``shell``
     Run a Django-aware interactive interpretter. `bpython` or `IPython` can be

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,13 @@ commands =
 
 [testenv:runserver]
 deps =
+    bpython
+    ipdb
+    pudb
     pywatchman
     {[testenv]deps}
+passenv =
+    PYTHONBREAKPOINT
 commands =
     python manage.py runserver
 


### PR DESCRIPTION
This introduces two enhancements to the `runserver` [tox][tox]
environment to make it easier to debug the application. First, it passes
the [`PYTHONBREAKPOINT` environment variable][breakpoint] into the
environment, allowing users to take advantage of the `breakpoint`
built-in. Second, it installs [bpdb][bpdb], [ipdb][ipdb], and
[pudb][pudb] into the environment to allow people to use the debugger
they're most comfortable using (similar to how the interface can be
controlled when using the `shell` environment).

[tox]: https://tox.readthedocs.io
[breakpoint]: https://www.python.org/dev/peps/pep-0553/#environment-variable
[pudb]: https://pypi.org/p/pudb
[bpdb]: https://bpython-interpreter.org
[ipdb]: https://pypi.org/p/ipdb