### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -11,7 +11,7 @@ repos:
         files: requirements\.in$
       - id: trailing-whitespace
   - repo: https://github.com/jazzband/pip-tools
-    rev: 5.1.2
+    rev: 5.2.0
     hooks:
       - id: pip-compile
       - id: pip-compile
@@ -42,7 +42,7 @@ repos:
       - id: black
         language_version: python3.8
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.2
     hooks:
       - id: flake8
         additional_dependencies:


### PR DESCRIPTION
These [pre-commit][pre-commit] hooks offer newer versions and are being
updated via:

    pre-commit autoupdate

[pre-commit]: https://pre-commit.com