### PR TITLE
Upgrade all of the requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile dev-requirements.in
 #
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 asgiref==3.2.7            # via django
-aspy.yaml==1.3.0          # via pre-commit
-cfgv==3.0.0               # via pre-commit
+cfgv==3.1.0               # via pre-commit
+distlib==0.3.0            # via virtualenv
 django-debug-toolbar==2.2  # via -r dev-requirements.in
-django==3.0.5             # via django-debug-toolbar
+django==3.0.7             # via django-debug-toolbar
 filelock==3.0.12          # via virtualenv
-identify==1.4.11          # via pre-commit
-nodeenv==1.3.5            # via pre-commit
-pre-commit==2.0.1         # via -r dev-requirements.in
-pytz==2019.3              # via django
-pyyaml==5.3               # via aspy.yaml, pre-commit
-six==1.14.0               # via virtualenv
+identify==1.4.19          # via pre-commit
+nodeenv==1.4.0            # via pre-commit
+pre-commit==2.4.0         # via -r dev-requirements.in
+pytz==2020.1              # via django
+pyyaml==5.3.1             # via pre-commit
+six==1.15.0               # via virtualenv
 sqlparse==0.3.1           # via django, django-debug-toolbar
-toml==0.10.0              # via pre-commit
-virtualenv==20.0.1        # via pre-commit
+toml==0.10.1              # via pre-commit
+virtualenv==20.0.21       # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@
 #    pip-compile
 #
 asgiref==3.2.7            # via django
-django-sesame==1.7        # via -r requirements.in
-django==3.0.5             # via -r requirements.in
-psycopg2-binary==2.8.4    # via -r requirements.in
+django-sesame==1.8        # via -r requirements.in
+django==3.0.7             # via -r requirements.in
+psycopg2-binary==2.8.5    # via -r requirements.in
 python-decouple==3.3      # via -r requirements.in
-pytz==2019.3              # via django
+pytz==2020.1              # via django
 sqlparse==0.3.1           # via django
 ua-parser==0.10.0         # via -r requirements.in

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,14 +4,14 @@
 #
 #    pip-compile test-requirements.in
 #
-appdirs==1.4.3            # via virtualenv
+appdirs==1.4.4            # via virtualenv
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-packaging==20.1           # via tox
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
-six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
-tox==3.14.5               # via -r test-requirements.in
-virtualenv==20.0.4        # via tox
+pyparsing==2.4.7          # via packaging
+six==1.15.0               # via packaging, tox, virtualenv
+toml==0.10.1              # via tox
+tox==3.15.1               # via -r test-requirements.in
+virtualenv==20.0.21       # via tox


### PR DESCRIPTION
[Django 3.0.7][django_3_0_7] is a security release. Rather than
upgrading it and leaving everything else alone, I'm taking the
opportunity to upgrade all of the dependencies listed in the project's
requirements files.

I did this by added `--upgrade` as an argument to each usage of the
`pip-compile` [pre-commit][pre-commit] hook. I then ran them using

    pre-commit run pip-compile --all-files

After that I discarded the changes to `.pre-commit-config.yaml`.

[django_3_0_7]: https://www.djangoproject.com/weblog/2020/jun/03/security-releases/
[pre-commit]: https://pre-commit.com