### PR TITLE
Add a homepage

### DIFF
--- a/src/awards/settings/base.py
+++ b/src/awards/settings/base.py
@@ -15,6 +15,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    "homepage",
     "applications",
     "users",
     "django.contrib.admin",

--- a/src/awards/urls.py
+++ b/src/awards/urls.py
@@ -1,10 +1,13 @@
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic.base import TemplateView
 
 from users.views import login, magic_login
 
 urlpatterns = [
+    # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+    path("", TemplateView.as_view(template_name="homepage/index.html")),
     # pyre doesn't include stubs for the Django admin.
     # TODO: Determine if we even want to use the admin.
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.

--- a/src/homepage/apps.py
+++ b/src/homepage/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class HomepageConfig(AppConfig):
+    name = "homepage"

--- a/src/homepage/templates/homepage/index.html
+++ b/src/homepage/templates/homepage/index.html
@@ -1,0 +1,2 @@
+<a href="{% url "scholarship" %}">I would like a ticket</a>
+<a href="{% url "financial_aid" %}">I would like travel reimbursement, lodging, and/or a ticket</a>


### PR DESCRIPTION
A new app is being added to introduce a homepage. All it does it render
the template that lets a visitor to the site select the type of aid for
which they'd like to apply.
