### PR TITLE
Provide a namespace for non-top level routes

### DIFF
--- a/src/applications/urls.py
+++ b/src/applications/urls.py
@@ -6,6 +6,8 @@ from applications.forms import (
 )
 from applications.views import apply, view
 
+app_name = "applications"
+
 urlpatterns = [
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
     path(
@@ -19,5 +21,5 @@ urlpatterns = [
         "ticket", apply, {"form_type": ScholarshipApplicationForm}, name="scholarship"
     ),
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
-    path("view/<int:pk>", view, name="application"),
+    path("view/<int:pk>", view, name="view"),
 ]

--- a/src/awards/urls.py
+++ b/src/awards/urls.py
@@ -13,13 +13,13 @@ urlpatterns = [
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
     path("admin/", admin.site.urls),  # type: ignore
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
-    path("apply/", include("applications.urls")),
+    path("apply/", include("applications.urls", namespace="applications")),
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
     path("login", login, name="login"),
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
     path("login/magic", magic_login, name="magic-login"),
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
-    path("users/", include("users.urls")),
+    path("users/", include("users.urls", namespace="users")),
 ]
 
 if settings.DEBUG:

--- a/src/homepage/templates/homepage/index.html
+++ b/src/homepage/templates/homepage/index.html
@@ -1,2 +1,2 @@
-<a href="{% url "scholarship" %}">I would like a ticket</a>
-<a href="{% url "financial_aid" %}">I would like travel reimbursement, lodging, and/or a ticket</a>
+<a href="{% url "applications:scholarship" %}">I would like a ticket</a>
+<a href="{% url "applications:financial_aid" %}">I would like travel reimbursement, lodging, and/or a ticket</a>

--- a/src/users/templates/users/profile.html
+++ b/src/users/templates/users/profile.html
@@ -1,3 +1,3 @@
 {% for application in applications %}
-  <a href="{% url "application" pk=application.id %}">{{ application }}</a>
+  <a href="{% url "applications:view" pk=application.id %}">{{ application }}</a>
 {% endfor %}

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from users.views import profile
 
+app_name = "users"
+
 urlpatterns = [
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
     path("profile", profile, name="profile"),


### PR DESCRIPTION
Without namespaces, using generic names (e.g., `view`) for routes is
problematic. By using a namespace, though, these generic names become
easier to use. The `application` route can be renamed to `view` because
it will be referenced as `applications:view`.
