### PR TITLE
Allow applicants to start over

### DIFF
--- a/src/applications/templates/applications/form.html
+++ b/src/applications/templates/applications/form.html
@@ -3,3 +3,5 @@
   {{ form }}
   <input type="submit" value="Submit application">
 </form>
+
+<a href="{% url "homepage" %}">Start over</a>

--- a/src/awards/urls.py
+++ b/src/awards/urls.py
@@ -7,7 +7,9 @@ from users.views import login, magic_login
 
 urlpatterns = [
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
-    path("", TemplateView.as_view(template_name="homepage/index.html")),
+    path(
+        "", TemplateView.as_view(template_name="homepage/index.html"), name="homepage"
+    ),
     # pyre doesn't include stubs for the Django admin.
     # TODO: Determine if we even want to use the admin.
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.


### PR DESCRIPTION
This will give applications a link to return to the homepage in case
they'd like to select the other award type. To simplify the use of the
`url` template tag, the route is being given the name `homepage`.
