### PR TITLE
Make applications editable

### DIFF
--- a/src/applications/templates/applications/form.html
+++ b/src/applications/templates/applications/form.html
@@ -4,4 +4,8 @@
   <input type="submit" value="Submit application">
 </form>
 
-<a href="{% url "homepage" %}">Start over</a>
+{% if form.instance.id %}
+  <a href="{% url "users:profile" %}">Never mind</a>
+{% else %}
+  <a href="{% url "homepage" %}">Start over</a>
+{% endif %}

--- a/src/applications/templates/applications/view.html
+++ b/src/applications/templates/applications/view.html
@@ -1,1 +1,3 @@
 {{ form }}
+
+<a href="{% url "applications:edit" pk=form.instance.id %}">Edit application</a>

--- a/src/applications/test_views.py
+++ b/src/applications/test_views.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model
+from django.http import Http404, HttpRequest
 from django.test import Client
 from factory.django import DjangoModelFactory
 import pytest
 from sesame.utils import get_query_string
 
 from applications.models import Application
+from applications.views import apply
 
 
 # pyre-ignore[13]: Investigate type stubs for factory-boy.
@@ -15,6 +17,8 @@ class ApplicationFactory(DjangoModelFactory):
         model = Application
 
     id: int
+    background = "BACKGROUND"
+    reason_to_attend = "REASON"
     type = Application.Type.SCHOLARSHIP
 
 
@@ -25,6 +29,42 @@ class UserFactory(DjangoModelFactory):
         django_get_or_create = ("email",)
 
     email = "user@example.org"
+
+
+@pytest.mark.django_db
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def test_that_one_of_form_type_and_pk_is_required_by_apply(client: Client) -> None:
+    user = UserFactory()
+    qs = get_query_string(user)
+    client.get(f"/login/magic{qs}")
+
+    request = HttpRequest()
+    request.user = user
+    # pyre-ignore[16]: pyre doesn't think ExceptionInfo as an __enter__.
+    with pytest.raises(Http404):
+        apply(request, form_type=None, pk=None)
+
+
+@pytest.mark.django_db
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def test_user_can_edit_their_application(client: Client) -> None:
+    user = UserFactory()
+    qs = get_query_string(user)
+    client.get(f"/login/magic{qs}")
+
+    # pyre-ignore[28]: Investigate type stubs for factory-boy.
+    application = ApplicationFactory(applicant=user)
+
+    expected = f"{application.background} changed"
+
+    response = client.post(
+        f"/apply/edit/{application.id}",
+        {"background": expected, "reason_to_attend": application.reason_to_attend},
+    )
+    assert response.status_code == 200
+
+    modified_application = Application.objects.get(pk=application.id)
+    assert modified_application.background == expected
 
 
 @pytest.mark.django_db

--- a/src/applications/urls.py
+++ b/src/applications/urls.py
@@ -10,6 +10,8 @@ app_name = "applications"
 
 urlpatterns = [
     # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+    path("edit/<int:pk>", apply, name="edit"),
+    # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
     path(
         "financial-aid",
         apply,

--- a/src/applications/views.py
+++ b/src/applications/views.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Type
+from typing import Optional, Type
 
 from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 
 from applications.forms import APPLICATION_FORM_TYPES, ApplicationForm
@@ -11,17 +11,36 @@ from applications.models import Application
 
 
 @login_required
-def apply(request: HttpRequest, form_type: Type[ApplicationForm]) -> HttpResponse:
-    if request.method == "POST":
+def apply(
+    request: HttpRequest,
+    form_type: Optional[Type[ApplicationForm]] = None,
+    pk: Optional[int] = None,
+) -> HttpResponse:
+    # If no form_type is provided, we're editing an existing
+    # application. Use it's primary key to look it up and determine
+    # which form type to use.
+    if form_type is None:
+        if pk is None:
+            # If neither value was provided, we shouldn't be here.
+            raise Http404()
+
+        application = get_object_or_404(Application, pk=pk, applicant=request.user)
+        form_type = APPLICATION_FORM_TYPES[application.type]
+    else:
         application = Application(applicant=request.user, type=form_type.type)
+
+    if request.method == "POST":
         form = form_type(request.POST, instance=application)
         if form.is_valid():
-
             form.save()
 
-            return HttpResponse("Thank you for your application")
+            if pk:
+                msg = "Your application has been updated"
+            else:
+                msg = "Thank you for your application"
+            return HttpResponse(msg)
     else:
-        form = form_type()
+        form = form_type(instance=application)
 
     return render(request, "applications/form.html", {"form": form})
 


### PR DESCRIPTION
This will extend `applications.views.apply` to support editing existing
applications. A new `pk` argument is being added and both it and
`form_type` are being marked as `Optional`. At least one of them is
required, with preference given to `form_type` if both are provided.

Closes #53
