### PR TITLE
Add a login link to the homepage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,7 @@ per-file-ignores =
     src/applications/migrations/0003_auto_20200507_0125.py: B950
     src/applications/models.py: B950
     src/applications/test_views.py: B950
+    src/homepage/test_views.py: B950
     src/users/migrations/0001_initial.py: B950
     src/users/forms.py: B950
     src/users/models.py: B950

--- a/src/homepage/templates/homepage/index.html
+++ b/src/homepage/templates/homepage/index.html
@@ -1,2 +1,7 @@
 <a href="{% url "applications:scholarship" %}">I would like a ticket</a>
 <a href="{% url "applications:financial_aid" %}">I would like travel reimbursement, lodging, and/or a ticket</a>
+
+{% if not request.user.is_authenticated %}
+  Already submitted an application? <a href="{% url "login" %}">log in</a> to
+  check its status.
+{% endif %}

--- a/src/homepage/test_views.py
+++ b/src/homepage/test_views.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import Client
+from factory.django import DjangoModelFactory
+import pytest
+from sesame.utils import get_query_string
+
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        # pyre-ignore[16]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+        model = get_user_model()
+        django_get_or_create = ("email",)
+
+    email = "user@example.org"
+
+
+@pytest.mark.django_db
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def test_login_link_is_not_shown_to_logged_in_users(client: Client) -> None:
+    user = UserFactory()
+    qs = get_query_string(user)
+    client.get(f"/login/magic{qs}")
+
+    response = client.get("/")
+    assert b"log in" not in response.content.lower()
+
+
+# pyre-ignore[11]: This is fixed by https://github.com/facebook/pyre-check/pull/256.
+def test_login_link_is_shown_to_guests(client: Client) -> None:
+    response = client.get("/")
+    assert b"log in" in response.content.lower()


### PR DESCRIPTION
Currently the only way to access your submitted applications is to
navigate directly to your profile or submit a new application. This will
let users log in if they're already submitted an application.
