### PR TITLE
Use namespace in redirect URL

### DIFF
--- a/src/users/views.py
+++ b/src/users/views.py
@@ -46,7 +46,7 @@ def login(request: HttpRequest) -> HttpResponse:
 def magic_login(request: HttpRequest) -> HttpResponse:
     user = get_user(request)
     if user:
-        return redirect("profile")
+        return redirect("users:profile")
     return redirect("oops")
 
 


### PR DESCRIPTION
Namespaces were added to a lot of routes in e3b7bd7. I updated the
templates but I missed the redirect after logging in.
