### PR TITLE
Add a base template

### DIFF
--- a/src/applications/templates/applications/form.html
+++ b/src/applications/templates/applications/form.html
@@ -1,11 +1,15 @@
-<form class="form" method="post">
-  {% csrf_token %}
-  {{ form }}
-  <input type="submit" value="Submit application">
-</form>
+{% extends "base.html" %}
 
-{% if form.instance.id %}
-  <a href="{% url "users:profile" %}">Never mind</a>
-{% else %}
-  <a href="{% url "homepage" %}">Start over</a>
-{% endif %}
+{% block content %}
+  <form class="form" method="post">
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" value="Submit application">
+  </form>
+
+  {% if form.instance.id %}
+    <a href="{% url "users:profile" %}">Never mind</a>
+  {% else %}
+    <a href="{% url "homepage" %}">Start over</a>
+  {% endif %}
+{% endblock %}

--- a/src/applications/templates/applications/view.html
+++ b/src/applications/templates/applications/view.html
@@ -1,3 +1,7 @@
-{{ form }}
+{% extends "base.html" %}
 
-<a href="{% url "applications:edit" pk=form.instance.id %}">Edit application</a>
+{% block content %}
+  {{ form }}
+
+  <a href="{% url "applications:edit" pk=form.instance.id %}">Edit application</a>
+{% endblock %}

--- a/src/awards/settings/base.py
+++ b/src/awards/settings/base.py
@@ -42,7 +42,7 @@ ROOT_URLCONF = "awards.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/src/awards/templates/base.html
+++ b/src/awards/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{% block title %}PyGotham Financial Awards{% endblock %}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block head %}{% endblock %}
+  </head>
+  <body>
+    {% block body %}
+      <nav>
+	{% if request.user.is_authenticated %}
+	  <a href="{% url "logout" %}">Log out</a>
+	{% endif %}
+      </nav>
+      {% block content %}{% endblock %}
+    {% endblock %}
+  </body>
+</html>

--- a/src/homepage/templates/homepage/index.html
+++ b/src/homepage/templates/homepage/index.html
@@ -1,7 +1,11 @@
-<a href="{% url "applications:scholarship" %}">I would like a ticket</a>
-<a href="{% url "applications:financial_aid" %}">I would like travel reimbursement, lodging, and/or a ticket</a>
+{% extends "base.html" %}
 
-{% if not request.user.is_authenticated %}
-  Already submitted an application? <a href="{% url "login" %}">Log in</a> to
-  check its status.
-{% endif %}
+{% block content %}
+  <a href="{% url "applications:scholarship" %}">I would like a ticket</a>
+  <a href="{% url "applications:financial_aid" %}">I would like travel reimbursement, lodging, and/or a ticket</a>
+
+  {% if not request.user.is_authenticated %}
+    Already submitted an application? <a href="{% url "login" %}">Log in</a> to
+    check its status.
+  {% endif %}
+{% endblock %}

--- a/src/users/templates/users/profile.html
+++ b/src/users/templates/users/profile.html
@@ -1,3 +1,7 @@
-{% for application in applications %}
-  <a href="{% url "applications:view" pk=application.id %}">{{ application }}</a>
-{% endfor %}
+{% extends "base.html" %}
+
+{% block content %}
+  {% for application in applications %}
+    <a href="{% url "applications:view" pk=application.id %}">{{ application }}</a>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Right now all this will do is set a page title and add a link to log
out, but getting this in while there are only a handful of templates
will make it easier to grow later.

The `TEMPLATES` setting needs to be updated in order to find the base
template in a [project-level `templates` folder][templates].

Closes #61

[templates]: https://docs.djangoproject.com/en/3.0/howto/overriding-templates/#overriding-from-the-project-s-templates-directory