### PR TITLE
Add tox environment to run Django's dbshell command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,9 @@ directory. To reduce the need to move back and worth between it and the root of
 the repository, several helpful management commands are exposed as tox
 environments.
 
+``dbshell``
+    Run |psql|_ for the configured database.
+
 ``makemigrations``
     Generate new migrations for installed applications.
 
@@ -111,6 +114,9 @@ environments.
 .. _citext: https://www.postgresql.org/docs/current/citext.html
 .. _ipython: https://ipython.readthedocs.io
 .. _PostgreSQL: https://www.postgresql.org
+.. _psql: https://www.postgresql.org/docs/current/app-psql.html
 .. _pyre: https://pyre-check.org
 .. _tox: https://tox.readthedocs.io
 .. _watchman: https://facebook.github.io/watchman/
+
+.. |psql| replace:: ``psql``

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,10 @@ setenv =
 changedir =
     {toxinidir}/src
 
+[testenv:dbshell]
+commands =
+    python manage.py dbshell
+
 [testenv:coverage]
 deps =
     coverage


### PR DESCRIPTION
[Django] provides a `dbshell` command that can be used to open up a CLI
for interacting with the database. In the case of Postgres, that's
[`psql`][psql]. Running this [tox] environment will use the same
database as the other tox environments.

[django]: https://www.djangoproject.com
[psql]: https://www.postgresql.org/docs/current/app-psql.html
[tox]: https://tox.readthedocs.io
