### PR TITLE
Fix links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ environments.
     * pudb
 
 ``shell``
-    Run a Django-aware interactive interpretter. `bpython` or `IPython` can be
+    Run a Django-aware interactive interpretter. bpython_ or IPython_ can be
     specified to select an interface other than the default Python REPL.
 
 ``startapp``
@@ -112,7 +112,7 @@ environments.
 
 .. _bpython: https://bpython-interpreter.org
 .. _citext: https://www.postgresql.org/docs/current/citext.html
-.. _ipython: https://ipython.readthedocs.io
+.. _IPython: https://ipython.readthedocs.io
 .. _PostgreSQL: https://www.postgresql.org
 .. _psql: https://www.postgresql.org/docs/current/app-psql.html
 .. _pyre: https://pyre-check.org


### PR DESCRIPTION
These bits of text were intended to be links (which is why they're
included in the URL block at the bottom of the README). This correctly
identifies them as such.
