### PR TITLE
Resume GitHub Actions for pushes to default branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   lint:


### PR DESCRIPTION
[GitHub Actions now has support][support] for running jobs on the
default branch, regardless of what its name is. This switches from using
`master` to `$default-branch`. Making this change will resume jobs for
pushes to the default branch which stopped when it was renamed.

[support]: https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/
