### PR TITLE
Pin the version of Pyre

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands =
 [testenv:types]
 deps =
     factory-boy
-    pyre-check
+    pyre-check==0.0.46
     pytest
     {[testenv]deps}
 commands =


### PR DESCRIPTION
In addition to making a bunch of our `pyre-ignore` comments unnecessary,
it seems to Pyre 0.0.48 surfaces a few type errors. This will pin the
version to 0.0.47 so that work can continue will the comments are
cleaned up and the errors are addressed.
