### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: seed-isort-config
         args: ['--application-directories=src']
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.4.2
+    rev: 5.5.4
     hooks:
       - id: isort
   - repo: https://github.com/psf/black


### PR DESCRIPTION
This [pre-commit] hook offers a newer version and is being updated via:

pre-commit autoupdate

[pre-commit]: https://pre-commit.com
