### PR TITLE
Add a note about Hacktoberfest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,18 @@ environments.
 ``startapp``
     Create a new Django application with the specified name.
 
+=============
+Hacktoberfest
+=============
+
+This project will accept and review pull requests submitted during
+Hacktoberfest_. PRs submitted with the sole purpose of earning a free t-shirt
+will be marked as spam. If this becomes a problem, the `hacktoberfest` topic
+will be removed from the repository.
+
 .. _bpython: https://bpython-interpreter.org
 .. _citext: https://www.postgresql.org/docs/current/citext.html
+.. _Hacktoberfest: https://hacktoberfest.digitalocean.com
 .. _ipython: https://ipython.readthedocs.io
 .. _PostgreSQL: https://www.postgresql.org
 .. _psql: https://www.postgresql.org/docs/current/app-psql.html


### PR DESCRIPTION
To reduce the burden on maintainers and to help combat spam,
[Hacktoberfest] has gone opt-in for 2020. As someone who has happily
participated in this event in the past, I'm accepting pull requests to
this project. This adds a note to let people know that spam PRs will be
rejected and I won't hesitate to pull the plug if it becomes a problem.

[hacktoberfest]: https://hacktoberfest.digitalocean.com
