### PR TITLE
Update the version of dependencies

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,2 +1,6 @@
+# TODO(dirn): Remove this as part of #80.
+# Django is a dependency of django-debug-toolbar. Without specifying the version
+# here, pip-compile would use the latest version.
+django>=3.0,<3.1
 django-debug-toolbar
 pre-commit

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,18 +5,18 @@
 #    pip-compile dev-requirements.in
 #
 appdirs==1.4.4            # via virtualenv
-asgiref==3.2.7            # via django
-cfgv==3.1.0               # via pre-commit
-distlib==0.3.0            # via virtualenv
-django-debug-toolbar==2.2  # via -r dev-requirements.in
-django==3.0.7             # via django-debug-toolbar
+asgiref==3.3.0            # via django
+cfgv==3.2.0               # via pre-commit
+distlib==0.3.1            # via virtualenv
+django-debug-toolbar==3.1.1  # via -r dev-requirements.in
+django==3.0.10            # via -r dev-requirements.in, django-debug-toolbar
 filelock==3.0.12          # via virtualenv
-identify==1.4.19          # via pre-commit
-nodeenv==1.4.0            # via pre-commit
-pre-commit==2.4.0         # via -r dev-requirements.in
+identify==1.5.6           # via pre-commit
+nodeenv==1.5.0            # via pre-commit
+pre-commit==2.7.1         # via -r dev-requirements.in
 pytz==2020.1              # via django
 pyyaml==5.3.1             # via pre-commit
 six==1.15.0               # via virtualenv
-sqlparse==0.3.1           # via django, django-debug-toolbar
+sqlparse==0.4.1           # via django, django-debug-toolbar
 toml==0.10.1              # via pre-commit
-virtualenv==20.0.21       # via pre-commit
+virtualenv==20.0.35       # via pre-commit

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django
+django>=3.0,<3.1
 django-sesame
 psycopg2-binary
 python-decouple

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile
 #
-asgiref==3.2.7            # via django
-django-sesame==1.8        # via -r requirements.in
-django==3.0.7             # via -r requirements.in
-psycopg2-binary==2.8.5    # via -r requirements.in
+asgiref==3.3.0            # via django
+django-sesame==2.0        # via -r requirements.in
+django==3.0.10            # via -r requirements.in, django-sesame
+psycopg2-binary==2.8.6    # via -r requirements.in
 python-decouple==3.3      # via -r requirements.in
 pytz==2020.1              # via django
-sqlparse==0.3.1           # via django
+sqlparse==0.4.1           # via django
 ua-parser==0.10.0         # via -r requirements.in

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,13 +5,13 @@
 #    pip-compile test-requirements.in
 #
 appdirs==1.4.4            # via virtualenv
-distlib==0.3.0            # via virtualenv
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.15.1               # via -r test-requirements.in
-virtualenv==20.0.21       # via tox
+tox==3.20.1               # via -r test-requirements.in
+virtualenv==20.0.35       # via tox


### PR DESCRIPTION
The only dependency not being updated here, at least not fully, is
[Django]. That's going to be done separately as part of #80. For now the
version is being fixed to the latest version of 3.0.

The Django version also has to be set for the development requirements.
Without doing so, the latest version would be pulled in by
[django-debug-toolbar]. This would lead to conflicting versions in CI as
some of the [tox] environments install both the development and regular
dependencies.

[django]: https://www.djangoproject.com
[django-debug-toolbar]: https://pypi.org/p/django-debug-toolbar
[tox]: https://tox.readthedocs.io