### PR TITLE
Clean up pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,18 +7,19 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
-        files: requirements\.in$
       - id: trailing-whitespace
   - repo: https://github.com/jazzband/pip-tools
     rev: 5.3.1
     hooks:
       - id: pip-compile
+        name: Compile requirements
       - id: pip-compile
+        name: Compile development requirements
         files: ^dev-requirements.(in|txt)$
         pass_filenames: false
         args: ["dev-requirements.in"]
       - id: pip-compile
+        name: Compile test requirements
         files: ^test-requirements.(in|txt)$
         pass_filenames: false
         args: ["test-requirements.in"]


### PR DESCRIPTION
Because the requirements files are generated by
[`pip-compile`][pip-tools], there's no need to run a fixer to sort them.
And names are being added to the hooks that run to generate these files.
By default `pip-compile` is used as the name, but it would be nice to
know which specific requirements file is being updated, especially when
being run by CI.

[pip-tools]: https://pypi.org/p/pip-tools
