### PR TITLE
Identify pip-tools pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,19 +7,18 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: requirements-txt-fixer
+        files: requirements\.in$
       - id: trailing-whitespace
   - repo: https://github.com/jazzband/pip-tools
     rev: 5.3.1
     hooks:
       - id: pip-compile
-        name: Compile requirements
       - id: pip-compile
-        name: Compile development requirements
         files: ^dev-requirements.(in|txt)$
         pass_filenames: false
         args: ["dev-requirements.in"]
       - id: pip-compile
-        name: Compile test requirements
         files: ^test-requirements.(in|txt)$
         pass_filenames: false
         args: ["test-requirements.in"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,14 @@ repos:
     rev: 5.3.1
     hooks:
       - id: pip-compile
+        name: Compile requirements
       - id: pip-compile
+        name: Compile development requirements
         files: ^dev-requirements.(in|txt)$
         pass_filenames: false
         args: ["dev-requirements.in"]
       - id: pip-compile
+        name: Compile test requirements
         files: ^test-requirements.(in|txt)$
         pass_filenames: false
         args: ["test-requirements.in"]


### PR DESCRIPTION
Names are being added to the [pip-tools] hooks that run to generate
requirements files. By default `pip-compile` is used as the name, but it
would be nice to know which specific requirements file is being updated,
especially when being run by CI.

(Note: this reverts an earlier attempt at this that removed a hook that is used
to sort the requirements source files.)

[pip-tools]: https://pypi.org/p/pip-tools
