### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -36,7 +36,7 @@ repos:
       - id: seed-isort-config
         args: ['--application-directories=src']
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.5.4
+    rev: 5.6.4
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
@@ -45,7 +45,7 @@ repos:
       - id: black
         language_version: python3.9
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
       - id: flake8
         additional_dependencies:


### PR DESCRIPTION
These [pre-commit] hooks offer newer versions and are being updated via:

    pre-commit autoupdate

[pre-commit]: https://pre-commit.com
