### PR TITLE
Let isort find third-party libraries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,7 +29,6 @@ indent_style = space
 atomic = true
 force_sort_within_sections = true
 include_trailing_comma = true
-known_third_party = decouple,django,factory,pytest,sesame
 multi_line_output = 3
 
 [.pyre_configuration]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,6 @@ repos:
     hooks:
       - id: autoflake
         args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-        args: ['--application-directories=src']
   - repo: https://github.com/timothycrosley/isort
     rev: 5.6.4
     hooks:


### PR DESCRIPTION
seed-isort-config is no longer needed as [isort] can find third-party
libraries on its own now. Its [pre-commit] hook as well as the
`known_third_party` block in the [EditorConfig] file are being removed.

[editorconfig]: https://editorconfig.org
[isort]: https://github.com/PyCQA/isort
[pre-commit]: https://pre-commit.com
