### PR TITLE
Use pre-commit ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,22 +7,6 @@ on:
       - $default-branch
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: set PY
-        run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - uses: pre-commit/action@v2.0.0
-
   migrations:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The [pre-commit] team now offer a [CI] service. In addition to running
the linters against pull requests, the service will automatically apply
the changes to the PR and update the hook versions.

[ci]: https://pre-commit.ci
[pre-commit]: https://pre-commit.com
