### PR TITLE
Update pip-tools pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         files: requirements\.in$
       - id: trailing-whitespace
   - repo: https://github.com/jazzband/pip-tools
-    rev: 5.3.1
+    rev: 5.4.0
     hooks:
       - id: pip-compile
         name: Compile requirements


### PR DESCRIPTION
The [pip-tools] [pre-commit] hook is being updated because the version
being used [runs into issues][issue] with older versions of pip.

[issue]: https://github.com/jazzband/pip-tools/issues/1228
[pip-tools]: https://pypi.org/p/pip-tools
[pre-commit]: https://pre-commit.com
