### PR TITLE
[CI] Remove use of deprecated set-env command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: set PY
-        run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: pre-commit/action@v2.0.0
 
   migrations:


### PR DESCRIPTION
The [`set-env` command has been fully disabled][setenv]. In addition to
removing the Python version from the cache's key, the key is being
updated to be more in line with cache keys used by the other CI jobs.

Closes #94

[pre-commit]: https://pre-commit.com
[setenv]: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
