### PR TITLE
[CI] Make CI work again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: set PY
-        run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: pre-commit/action@v2.0.0
 
   migrations:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         files: requirements\.in$
       - id: trailing-whitespace
   - repo: https://github.com/jazzband/pip-tools
-    rev: 5.3.1
+    rev: 5.4.0
     hooks:
       - id: pip-compile
         name: Compile requirements

--- a/src/applications/test_views.py
+++ b/src/applications/test_views.py
@@ -40,7 +40,6 @@ def test_that_one_of_form_type_and_pk_is_required_by_apply(client: Client) -> No
 
     request = HttpRequest()
     request.user = user
-    # pyre-ignore[16]: pyre doesn't think ExceptionInfo as an __enter__.
     with pytest.raises(Http404):
         apply(request, form_type=None, pk=None)
 


### PR DESCRIPTION
Our CI is currently in a failing state due to some things that have changed with
our tooling:

* GitHub has disabled the `set-env` command in actions
* the version of pip-tools used doesn't work with recent pip releases
* a `pyre-ignore` comment is no longer suppressing an error

Any PR aimed at fixing [one] [of] [these] will fail because of the others. This
PR will fix all of them instead.

[one]: https://github.com/PyGotham/awards/pull/96
[of]: https://github.com/PyGotham/awards/pull/97
[these]: https://github.com/PyGotham/awards/pull/98
