### PR TITLE
Allow merge commits to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
           python-version: 3.9
 
       - uses: pre-commit/action@v2.0.3
+        env:
+          SKIP: no-commit-to-branch
 
   # Run the test suite and type checks.
   tox:


### PR DESCRIPTION
[GitHub Actions][actions] runs [pre-commit] for each new pull request
and whenever a new commit is pushed to `main`. The only time the latter
should ever happen, though, is when a pull request is merged.

Unfortunately [pre-commit]'s `no-commit-to-branch` hook doesn't seem to
like the idea of the merge commit being added to `main`. Fortunately
[pre-commit] allows you to skip one of more hooks by setting the `SKIP`
environment variable.

[actions]: https://docs.github.com/en/actions
[pre-commit]: https://pre-commit.com
