### PR TITLE
Load configuration

### DIFF
--- a/awards/settings/prod.py
+++ b/awards/settings/prod.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from decouple import config  # type: ignore[import]
+
 from awards.settings.base import *  # NOQA
 
-# TODO(dirn): Figure out how we want to pull in environment variables
-# and/or configuration settings.
-SECRET_KEY = "secret key for production"
+SECRET_KEY = config("SECRET_KEY")
 
 DEBUG = False

--- a/poetry.lock
+++ b/poetry.lock
@@ -684,6 +684,14 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["django", "django-configurations (>=2.0)"]
 
 [[package]]
+name = "python-decouple"
+version = "3.5"
+description = "Strict separation of settings from code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
@@ -897,7 +905,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "64711b189b812d57f47a3350e0490755b190cd3004af5c020c6ae23ac77c4f47"
+content-hash = "914efbf2a746822bde6963ee7b32ef58e0106d2f3c1609bac5e8294b2bc4ceae"
 
 [metadata.files]
 appnope = [
@@ -1225,6 +1233,9 @@ pytest = [
 pytest-django = [
     {file = "pytest-django-4.4.0.tar.gz", hash = "sha256:b5171e3798bf7e3fc5ea7072fe87324db67a4dd9f1192b037fed4cc3c1b7f455"},
     {file = "pytest_django-4.4.0-py3-none-any.whl", hash = "sha256:65783e78382456528bd9d79a35843adde9e6a47347b20464eb2c885cb0f1f606"},
+]
+python-decouple = [
+    {file = "python-decouple-3.5.tar.gz", hash = "sha256:68e4b3fcc97e24bc90eecc514852d0bf970f4ff031f5f7a6728ddafa9afefcaf"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/PyGotham/awards"
 [tool.poetry.dependencies]
 Django = "^3.2.7"
 python = "^3.9"
+python-decouple = "^3.5"
 
 [tool.poetry.dev-dependencies]
 black = "^21.8b0"


### PR DESCRIPTION
[python-decouple][decouple] provides a nice way to deal with application
configuration. It can read from both environment variables and
configuration files. And it can return default values and values cast as
specific types.

With the help of [python-decouple][decouple], the production value for
`SECRET_KEY` can now be pushed out of the settings module and into
configuration.

[decouple]: https://github.com/henriquebastos/python-decouple
