### PR TITLE
Group Django and stubs for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
       interval: "weekly"
     pull-request-branch-name:
       separator: "-"
+    groups:
+      django:
+        patterns:
+          - "django"
+          - "django-stubs"


### PR DESCRIPTION
When Dependabot sends pull requests for Django and django-stubs at the
same time, there is always a chance that something will fail when one is
merged before the other. This should tell Dependabot to send a single
pull request for both libraries rather than separate ones.
