### PR TITLE
Add pre-commit hook pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
     hooks:
       - id: editorconfig-checker
         alias: ec
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+      - id: pyupgrade
+        args: ['--py311-plus']
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.2.1
     hooks:


### PR DESCRIPTION
[pyupgrade] can be used as a [pre-commit] hook to update syntax to match
newer versions of Python.

[pre-commit]: https://pre-commit.com
[pyupgrade]: https://pypi.org/p/pyupgrade
