### PR TITLE
Group flake8 and its plugins for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
         patterns:
           - "django"
           - "django-stubs"
+      flake8:
+        patterns:
+          - "flake8*"
+          - "pep8-naming"


### PR DESCRIPTION
This creates a package group for flake8 and its plugins. While these
don't update too frequently, it will be nice to batch them together when
they do.
